### PR TITLE
Warning for stay alive script

### DIFF
--- a/GMnetENGINE.gmx/scripts/mp_stayAlive.gml
+++ b/GMnetENGINE.gmx/scripts/mp_stayAlive.gml
@@ -18,3 +18,4 @@
 */
 
 self.htme_mp_stayAlive = true;
+if persistent=false htme_debugger("mp_stayAlive",htme_debug.WARNING,"Instance is in stay alive mode but not currently persistent!");

--- a/GMnetENGINE.gmx/scripts/mp_stayAlive.gml
+++ b/GMnetENGINE.gmx/scripts/mp_stayAlive.gml
@@ -18,4 +18,7 @@
 */
 
 self.htme_mp_stayAlive = true;
-if persistent=false htme_debugger("mp_stayAlive",htme_debug.WARNING,"Instance is in stay alive mode but not currently persistent!");
+if (persistent == false) {
+        htme_debugger("mp_stayAlive",htme_debug.WARNING,"Instance is in stay alive mode but not currently persistent!");
+        persistent = true;
+    }


### PR DESCRIPTION
Warning for stay alive is not set to persistent.
This little warning will help frustrating programmers (like me :-) that miss to set the persistent check-box and the gmnet engine will then crash.