### PR TITLE
Fix unsync bug

### DIFF
--- a/GMnetENGINE.gmx/scripts/htme_roomend.gml
+++ b/GMnetENGINE.gmx/scripts/htme_roomend.gml
@@ -51,9 +51,7 @@ for(var i=0; i<ds_map_size(m); i+=1) {
            /* (1) */
            htme_debugger("htme_roomend",htme_debug.DEBUG,"Unregistered a global instance "+insthash+"!");
            if (!self.isServer) {
-              var new_insthash = ds_map_find_next(m, insthash);
               ds_map_delete(self.globalInstances,insthash);
-              ds_map_delete(m,insthash);
            }
            /* (2) */ 
            if ((instid).persistent) {
@@ -68,12 +66,8 @@ for(var i=0; i<ds_map_size(m); i+=1) {
     else {
         htme_debugger("htme_roomend",htme_debug.WARNING,"Undefined found in globalInstances");
     }
-    if (!is_undefined(new_insthash)) {
-        insthash = new_insthash;
-        new_insthash = undefined;
-    } else {
-        insthash = ds_map_find_next(m, insthash);
-    }
+    // Get next
+    insthash = ds_map_find_next(m, insthash);
 }
 
 htme_forceSyncLocalInstances(self.playerhash);


### PR DESCRIPTION
ds_map_size(m) is changed when use ds_map_delete(m,insthash); and the
loop will quit early. Before thw whole map is checked. We must preserve
the m map to the last end or redo the loop and set i=0. Tested with 5
players and all works well with this fix.

This is an unfix from 8db2dbd414e4e065076a104fde112a5c906b0da4