### PR TITLE
Error when connection fail

### DIFF
--- a/GMnetENGINE.gmx/scripts/htme_clientConnectionFailed.gml
+++ b/GMnetENGINE.gmx/scripts/htme_clientConnectionFailed.gml
@@ -18,6 +18,14 @@
 **
 */
 
-with (global.htme_object) {
-    return self.clientStopped;
+// Check if obj_htme exists (udphp_stopClient may have destroyed it when connection falied)
+if instance_exists(global.htme_object)
+{
+    with (global.htme_object) {
+        return self.clientStopped;
+    }
+}
+else
+{
+    return true;
 }

--- a/GMnetENGINE.gmx/scripts/htme_clientIsConnected.gml
+++ b/GMnetENGINE.gmx/scripts/htme_clientIsConnected.gml
@@ -16,8 +16,16 @@
 **
 */
 
-with (global.htme_object) {
-    //Connection isn't finished if we don't have a playerhash.
-    if (self.playerhash == "") return false;
-    return self.isConnected;
+// Check if obj_htme exists (udphp_stopClient may have destroyed it when connection falied)
+if instance_exists(global.htme_object)
+{
+    with (global.htme_object) {
+        //Connection isn't finished if we don't have a playerhash.
+        if (self.playerhash == "") return false;
+        return self.isConnected;
+    }
+}
+else
+{
+    return false;
 }

--- a/GMnetENGINE.gmx/scripts/htme_debugOverlayEnabled.gml
+++ b/GMnetENGINE.gmx/scripts/htme_debugOverlayEnabled.gml
@@ -16,4 +16,12 @@
 **
 */
 
-return global.htme_object.debugoverlay;
+// Check if obj_htme exists (udphp_stopClient may have destroyed it when connection falied)
+if instance_exists(global.htme_object)
+{
+    return global.htme_object.debugoverlay;
+}
+else
+{
+    return false;
+}


### PR DESCRIPTION
When connection fail the client is still in the connecting room. That is
because the script udphp_stopClient() destroy the obj_htme. And the
script htme_clientConnectionFailed dont check if the obj_htme still
exists. The scripts htme_clientIsConnected and htme_debugOverlayEnabled
is also fixed to handle this new client stop procedure.