### PR TITLE
Delta time to connection

### DIFF
--- a/GMnetENGINE.gmx/GMnetENGINE.project.gmx
+++ b/GMnetENGINE.gmx/GMnetENGINE.project.gmx
@@ -81,6 +81,7 @@
         <script>scripts\udphp_string_explode.gml</script>
         <script>scripts\udphp_handleerror.gml</script>
         <script>scripts\udphp_punchstate.gml</script>
+        <script>scripts\udphp_get_count.gml</script>
       </scripts>
       <scripts name="lobby">
         <script>scripts\udphp_downloadNetworking.gml</script>
@@ -98,6 +99,7 @@
         <script>scripts\htme_ds_map_find_key.gml</script>
         <script>scripts\htme_playerMapPort.gml</script>
         <script>scripts\htme_playerMapIP.gml</script>
+        <script>scripts\htme_get_count.gml</script>
       </scripts>
       <scripts name="tools">
         <script>scripts\htme_isLocal.gml</script>

--- a/GMnetENGINE.gmx/scripts/htme_clientCheckConnection.gml
+++ b/GMnetENGINE.gmx/scripts/htme_clientCheckConnection.gml
@@ -38,6 +38,6 @@ if (self.clientTimeoutRecv < 0) {
     return false;
 }
 
-self.clientTimeoutSend-=delta_time*0.000001;
-self.clientTimeoutRecv-=delta_time*0.000001;
+self.clientTimeoutSend-=htme_get_count();
+self.clientTimeoutRecv-=htme_get_count();
 return true;

--- a/GMnetENGINE.gmx/scripts/htme_clientCheckConnection.gml
+++ b/GMnetENGINE.gmx/scripts/htme_clientCheckConnection.gml
@@ -38,6 +38,6 @@ if (self.clientTimeoutRecv < 0) {
     return false;
 }
 
-self.clientTimeoutSend--;
-self.clientTimeoutRecv--;
+self.clientTimeoutSend-=delta_time*0.000001;
+self.clientTimeoutRecv-=delta_time*0.000001;
 return true;

--- a/GMnetENGINE.gmx/scripts/htme_clientConnect.gml
+++ b/GMnetENGINE.gmx/scripts/htme_clientConnect.gml
@@ -21,7 +21,7 @@
 if (!self.isConnected) {
     //Connect to server now!
     htme_debugger("htme_clientStart",htme_debug.DEBUG,"Connecting with server "+string(server_ip)+":"+string(server_port))
-    self.client_timeout++;
+    self.client_timeout+=delta_time*0.000001;
     //Send a packet to the server to request connection. If this reaches the server, he will
     //add us to the list of players and send an answer.
     buffer_seek(self.buffer, buffer_seek_start, 0);

--- a/GMnetENGINE.gmx/scripts/htme_clientConnect.gml
+++ b/GMnetENGINE.gmx/scripts/htme_clientConnect.gml
@@ -21,7 +21,7 @@
 if (!self.isConnected) {
     //Connect to server now!
     htme_debugger("htme_clientStart",htme_debug.DEBUG,"Connecting with server "+string(server_ip)+":"+string(server_port))
-    self.client_timeout+=delta_time*0.000001;
+    self.client_timeout+=htme_get_count();
     //Send a packet to the server to request connection. If this reaches the server, he will
     //add us to the list of players and send an answer.
     buffer_seek(self.buffer, buffer_seek_start, 0);

--- a/GMnetENGINE.gmx/scripts/htme_config.gml
+++ b/GMnetENGINE.gmx/scripts/htme_config.gml
@@ -55,7 +55,7 @@ self.udphp_master_port = 6510;
  * The server will only reconnect if it's no longer connected.
  * @type real
  */
-self.udphp_rctintv = 3*60*room_speed;
+self.udphp_rctintv = 3*60;
 
 /** 
  * The timeout after which the client gives up to connect.
@@ -65,7 +65,7 @@ self.udphp_rctintv = 3*60*room_speed;
  * The timeout after which the server and client give up to connect to each other.
  * @type real
  */
-self.global_timeout = 5*room_speed;
+self.global_timeout = 5;
 
 /** 
  * WHEN USING GMnet PUNCH:
@@ -73,17 +73,17 @@ self.global_timeout = 5*room_speed;
  *
  * The time the punch stage will wait before trying next port
  * Increase self.global_timeout to test more ports if you have problem connecting with punch
- * If you experience overload in the router set the value to room_speed*2 or above.
+ * If you experience overload in the router set the value to 2 or above.
  * But this will decrease the chances you connect to the server
  * @type real
  */
-self.punch_stage_timeout=room_speed; // must wait 1 sec before next try else the Messages wont be sent or the target router will stop them
+self.punch_stage_timeout=1; // must wait 1 sec before next try else the Messages wont be sent or the target router will stop them
 
 /** 
  * Interval the servers broadcast data to the LAN, for the LAN lobby
  * @type real
  */
-self.lan_interval = 15*room_speed;
+self.lan_interval = 15;
 
 /**
  *  Shortname of this game

--- a/GMnetENGINE.gmx/scripts/htme_get_count.gml
+++ b/GMnetENGINE.gmx/scripts/htme_get_count.gml
@@ -1,0 +1,18 @@
+/// htme_get_count();
+
+/*  INTERNAL COMMAND
+**  Description:
+**      Get step time or delta time to the counter who call this script
+**  
+**  Usage:
+**      htme_get_count()
+**
+**  Returns:
+**      real (step 1 or delta time)
+**
+*/
+if global.htme_object.use_delta_time {
+    return delta_time*0.000001;
+} else {
+    return 1;
+}

--- a/GMnetENGINE.gmx/scripts/htme_init.gml
+++ b/GMnetENGINE.gmx/scripts/htme_init.gml
@@ -137,7 +137,7 @@ if (self.use_udphp) {
     if (self.debuglevel <= htme_debug.INFO) {u_debug=false;u_silent=false;}
     if (self.debuglevel <= htme_debug.DEBUG) {u_debug=true;u_silent=false;}
     if (self.debuglevel == htme_debug.TRAFFIC) {u_debug=false;u_silent=true;}
-    script_execute(asset_get_index("udphp_config"),self.udphp_master_ip, self.udphp_master_port,self.udphp_rctintv,self.global_timeout,u_debug,u_silent);
+    script_execute(asset_get_index("udphp_config"),self.udphp_master_ip, self.udphp_master_port,self.udphp_rctintv,self.global_timeout,u_debug,u_silent,self.use_delta_time);
     //Set some additional PUNCH variables
     global.udphp_punch_stage_timeout_initial = self.punch_stage_timeout;
 }

--- a/GMnetENGINE.gmx/scripts/htme_serverBroadcast.gml
+++ b/GMnetENGINE.gmx/scripts/htme_serverBroadcast.gml
@@ -30,5 +30,5 @@ if (self.lan_intervalpnt >= self.lan_interval) {
     network_send_broadcast(self.socketOrServer, self.port+1, self.buffer, buffer_tell(self.buffer));
     self.lan_intervalpnt = 0;
 } else {
-    self.lan_intervalpnt++;
+    self.lan_intervalpnt+=delta_time*0.000001;
 }

--- a/GMnetENGINE.gmx/scripts/htme_serverBroadcast.gml
+++ b/GMnetENGINE.gmx/scripts/htme_serverBroadcast.gml
@@ -30,5 +30,5 @@ if (self.lan_intervalpnt >= self.lan_interval) {
     network_send_broadcast(self.socketOrServer, self.port+1, self.buffer, buffer_tell(self.buffer));
     self.lan_intervalpnt = 0;
 } else {
-    self.lan_intervalpnt+=delta_time*0.000001;
+    self.lan_intervalpnt+=htme_get_count();
 }

--- a/GMnetENGINE.gmx/scripts/htme_serverCheckConnections.gml
+++ b/GMnetENGINE.gmx/scripts/htme_serverCheckConnections.gml
@@ -58,7 +58,7 @@ for(var i=0; i<ds_map_size(self.playermap); i+=1) {
         //FIXME: We can't check any other clients this step, because the loop is now brocken
         exit;
     }
-    ds_map_replace(self.serverTimeoutSend,key, timeoutSend-delta_time*0.000001);
-    ds_map_replace(self.serverTimeoutRecv,key, timeoutRecv-delta_time*0.000001);
+    ds_map_replace(self.serverTimeoutSend,key, timeoutSend-htme_get_count());
+    ds_map_replace(self.serverTimeoutRecv,key, timeoutRecv-htme_get_count());
     key = ds_map_find_next(self.playermap, key);
 }

--- a/GMnetENGINE.gmx/scripts/htme_serverCheckConnections.gml
+++ b/GMnetENGINE.gmx/scripts/htme_serverCheckConnections.gml
@@ -58,7 +58,7 @@ for(var i=0; i<ds_map_size(self.playermap); i+=1) {
         //FIXME: We can't check any other clients this step, because the loop is now brocken
         exit;
     }
-    ds_map_replace(self.serverTimeoutSend,key, timeoutSend-1);
-    ds_map_replace(self.serverTimeoutRecv,key, timeoutRecv-1);
+    ds_map_replace(self.serverTimeoutSend,key, timeoutSend-delta_time*0.000001);
+    ds_map_replace(self.serverTimeoutRecv,key, timeoutRecv-delta_time*0.000001);
     key = ds_map_find_next(self.playermap, key);
 }

--- a/GMnetENGINE.gmx/scripts/htme_syncInstances.gml
+++ b/GMnetENGINE.gmx/scripts/htme_syncInstances.gml
@@ -31,6 +31,6 @@ for(var i=0; i<ds_list_size(self.grouplist_local); i+=1) {
         htme_syncSingleVarGroup(group,all);
         group[? "__counter"] = group[? "interval"];
     } else {
-        group[? "__counter"] = group[? "__counter"]-1;
+        group[? "__counter"] = group[? "__counter"]-htme_get_count();
     }
 }

--- a/GMnetENGINE.gmx/scripts/udphp_clientPunch.gml
+++ b/GMnetENGINE.gmx/scripts/udphp_clientPunch.gml
@@ -43,7 +43,7 @@ if (!client.connected) {
     if (client.directconnect) {
         //DIRECT CONNECT or GOT SERVER PORT (and can now connect directly)
         udphp_handleerror(udphp_dbglvl.DEBUG, udphp_dbgtarget.CLIENT, client, "Connecting with server "+string(client.server_ip)+":"+string(client.server_port))
-        client.timeout+=delta_time*0.000001;
+        client.timeout+=udphp_get_count();
         //Send a packet to the server to punch the hole. If this reaches the server, he will
         //add us to the list of players and send an answer.
         buffer_seek(client.buffer, buffer_seek_start, 0);

--- a/GMnetENGINE.gmx/scripts/udphp_clientPunch.gml
+++ b/GMnetENGINE.gmx/scripts/udphp_clientPunch.gml
@@ -43,7 +43,7 @@ if (!client.connected) {
     if (client.directconnect) {
         //DIRECT CONNECT or GOT SERVER PORT (and can now connect directly)
         udphp_handleerror(udphp_dbglvl.DEBUG, udphp_dbgtarget.CLIENT, client, "Connecting with server "+string(client.server_ip)+":"+string(client.server_port))
-        client.timeout++;
+        client.timeout+=delta_time*0.000001;
         //Send a packet to the server to punch the hole. If this reaches the server, he will
         //add us to the list of players and send an answer.
         buffer_seek(client.buffer, buffer_seek_start, 0);
@@ -52,8 +52,8 @@ if (!client.connected) {
         udphp_punchstate(client);
 
         // Change punch stages depending on the total timeout
-        if (client.punch_stage != udphp_punch_states.TRY_SEQUENCE_PORT && 
-          client.timeout == floor(global_timeout*(udphp_punch_states.TRY_SEQUENCE_PORT/100))) {
+        if (client.punch_stage < udphp_punch_states.TRY_SEQUENCE_PORT && 
+          client.timeout > global_timeout*(udphp_punch_states.TRY_SEQUENCE_PORT/100)) {
             // Try change the external server port
             // If the server NAT changed the port to a sequencent port nearby the received port from master server
             // Some NAT change the external port when external ip change in the send network message.
@@ -63,8 +63,8 @@ if (!client.connected) {
             // Only config this once
             client.punch_stage = udphp_punch_states.TRY_SEQUENCE_PORT;
             
-        } else if (client.punch_stage != udphp_punch_states.TRY_PREDICTING_PORT && 
-          client.timeout == floor((global_timeout*udphp_punch_states.TRY_PREDICTING_PORT/100))) {
+        } else if (client.punch_stage < udphp_punch_states.TRY_PREDICTING_PORT && 
+          client.timeout > (global_timeout*udphp_punch_states.TRY_PREDICTING_PORT/100)) {
             // Try change the external server port
             // If the server NAT changed the port to a random port
             // We can use the last port from the master server as a max and min to predict the next port

--- a/GMnetENGINE.gmx/scripts/udphp_config.gml
+++ b/GMnetENGINE.gmx/scripts/udphp_config.gml
@@ -1,4 +1,4 @@
-///udphp_config(master_ip,master_port,reconnect_intv,timeouts,debug,silent)
+///udphp_config(master_ip,master_port,reconnect_intv,timeouts,debug,silent,delta time)
 
 /*
 **  Description:
@@ -20,6 +20,8 @@
 **      silent            boolean   If true, log nothing, alert on nothing.
 **                                  Default setting: Log debug and warning, alert on error
 **                                  (ignored if debug is set to true) 
+**      delta time        boolean   If true, use delta time insted of step time
+**                                  Default setting: false
 **
 **  Returns:
 **      <nothing>
@@ -84,6 +86,7 @@ var reconnect_intv = argument2;
 var timeouts = argument3;
 var debug = argument4;
 var silent = argument5;
+var deltatime = argument6;
 
 /** Set timeout for master server connection
   * TODO: Add option to specify this value
@@ -123,7 +126,7 @@ global.udphp_tmp_data7 = "";
 global.udphp_tmp_data8 = "";
 global.udphp_clients = ds_map_create();
 global.udphp_version = "1.2.4";
-
+global.udphp_deltatime = deltatime;
 global.udphp_downloadlist_refreshing = false;
 global.udphp_downloadlist_topmap = -1;
 global.udphp_downloadlist = -1;

--- a/GMnetENGINE.gmx/scripts/udphp_config.gml
+++ b/GMnetENGINE.gmx/scripts/udphp_config.gml
@@ -39,14 +39,14 @@
  * PORT PREDICTION TIMEOUTS
  * The time the punch stage will wait before trying next port
  * Increase timeouts to test more ports if you have problem connecting with punch
- * If you experience overload in the router set the value to room_speed*2 or above.
+ * If you experience overload in the router set the value to 2 or above.
  * But this will decrease the chances you connect to the server
  *
  * GMnet ENGINE users can change this setting in htme_config!
  *
  * @type real
  */
-global.udphp_punch_stage_timeout_initial = room_speed;
+global.udphp_punch_stage_timeout_initial = 1;
 
 //====== END CONFIGURATION ==========//
 

--- a/GMnetENGINE.gmx/scripts/udphp_get_count.gml
+++ b/GMnetENGINE.gmx/scripts/udphp_get_count.gml
@@ -1,0 +1,18 @@
+/// udphp_get_count();
+
+/*  INTERNAL COMMAND
+**  Description:
+**      Get step time or delta time to the counter who call this script
+**  
+**  Usage:
+**      udphp_get_count()
+**
+**  Returns:
+**      real (step 1 or delta time)
+**
+*/
+if global.udphp_deltatime {
+    return delta_time*0.000001;
+} else {
+    return 1;
+}

--- a/GMnetENGINE.gmx/scripts/udphp_punchstate.gml
+++ b/GMnetENGINE.gmx/scripts/udphp_punchstate.gml
@@ -46,7 +46,7 @@ switch (client.punch_stage)
                 // Send message and try to connect to server
                 network_send_udp( client.udp_socket, client.server_ip, client.punch_stage_external_server_port+client.punch_stage_counter, client.buffer, buffer_tell(client.buffer) );            
                 // Wait some to test the other port
-                client.punch_stage_timeout-=1;
+                client.punch_stage_timeout-=delta_time*0.000001;
                 // Timeout on this port try another one
                 if (client.punch_stage_timeout<=0) {
                     client.punch_stage_sub1=udphp_punch_substates.DEFAULT;
@@ -125,7 +125,7 @@ switch (client.punch_stage)
                 break;
             case udphp_punch_substates.PRED_REST:
                 // Wait some to test the new port
-                client.punch_stage_timeout-=1;
+                client.punch_stage_timeout-=delta_time*0.000001;
                 // Timeout on this port try another one
                 if client.punch_stage_timeout<=0 
                 {

--- a/GMnetENGINE.gmx/scripts/udphp_punchstate.gml
+++ b/GMnetENGINE.gmx/scripts/udphp_punchstate.gml
@@ -46,7 +46,7 @@ switch (client.punch_stage)
                 // Send message and try to connect to server
                 network_send_udp( client.udp_socket, client.server_ip, client.punch_stage_external_server_port+client.punch_stage_counter, client.buffer, buffer_tell(client.buffer) );            
                 // Wait some to test the other port
-                client.punch_stage_timeout-=delta_time*0.000001;
+                client.punch_stage_timeout-=udphp_get_count();
                 // Timeout on this port try another one
                 if (client.punch_stage_timeout<=0) {
                     client.punch_stage_sub1=udphp_punch_substates.DEFAULT;
@@ -125,7 +125,7 @@ switch (client.punch_stage)
                 break;
             case udphp_punch_substates.PRED_REST:
                 // Wait some to test the new port
-                client.punch_stage_timeout-=delta_time*0.000001;
+                client.punch_stage_timeout-=udphp_get_count();
                 // Timeout on this port try another one
                 if client.punch_stage_timeout<=0 
                 {

--- a/GMnetENGINE.gmx/scripts/udphp_serverPunch.gml
+++ b/GMnetENGINE.gmx/scripts/udphp_serverPunch.gml
@@ -90,7 +90,7 @@ if (global.udphp_server_counter < 1) {
         //connect directly and we will try to reconnect next time.
     }
     global.udphp_server_counter = global.udphp_server_reconnect; //reset counter
-} else global.udphp_server_counter--;
+} else global.udphp_server_counter-=delta_time*0.000001;
 
 
 
@@ -127,7 +127,7 @@ for(i=0; i<ds_map_size(incoming_requests); i+=1) {
         buffer_seek(buffer, buffer_seek_start, 0);
         buffer_write(buffer, buffer_s8, udphp_packet.KNOCKKNOCK);
         network_send_udp(server,ip,port,buffer,buffer_tell(buffer));
-        timeout++;
+        timeout+=delta_time*0.000001;
         ds_map_replace(incoming_requests,key,timeout); 
     }
     //loop releated stuff
@@ -157,7 +157,7 @@ for(i=0; i<ds_map_size(incoming_requests2); i+=1) {
     udphp_handleerror(udphp_dbglvl.DEBUG, udphp_dbgtarget.SERVER, 0, "Making "+ip+" aware we are connected.");
     
     //We are using 3 seconds as a fixed timeout for now
-    if (timeout > 3*room_speed) {
+    if (timeout > 3) {
         //Timeout has been reached, stop sending
         delete = true;
     } else {
@@ -165,7 +165,7 @@ for(i=0; i<ds_map_size(incoming_requests2); i+=1) {
         buffer_seek(buffer, buffer_seek_start, 0);
         buffer_write(buffer, buffer_s8, udphp_packet.SERVWELCOME);
         network_send_udp(global.udphp_server_udp,ip,port,buffer,buffer_tell(buffer));
-        timeout++;
+        timeout+=delta_time*0.000001;
         ds_map_replace(incoming_requests2,key,timeout); 
     }
     //loop releated stuff

--- a/GMnetENGINE.gmx/scripts/udphp_serverPunch.gml
+++ b/GMnetENGINE.gmx/scripts/udphp_serverPunch.gml
@@ -90,7 +90,7 @@ if (global.udphp_server_counter < 1) {
         //connect directly and we will try to reconnect next time.
     }
     global.udphp_server_counter = global.udphp_server_reconnect; //reset counter
-} else global.udphp_server_counter-=delta_time*0.000001;
+} else global.udphp_server_counter-=udphp_get_count();
 
 
 
@@ -127,7 +127,7 @@ for(i=0; i<ds_map_size(incoming_requests); i+=1) {
         buffer_seek(buffer, buffer_seek_start, 0);
         buffer_write(buffer, buffer_s8, udphp_packet.KNOCKKNOCK);
         network_send_udp(server,ip,port,buffer,buffer_tell(buffer));
-        timeout+=delta_time*0.000001;
+        timeout+=udphp_get_count();
         ds_map_replace(incoming_requests,key,timeout); 
     }
     //loop releated stuff
@@ -165,7 +165,7 @@ for(i=0; i<ds_map_size(incoming_requests2); i+=1) {
         buffer_seek(buffer, buffer_seek_start, 0);
         buffer_write(buffer, buffer_s8, udphp_packet.SERVWELCOME);
         network_send_udp(global.udphp_server_udp,ip,port,buffer,buffer_tell(buffer));
-        timeout+=delta_time*0.000001;
+        timeout+=udphp_get_count();
         ds_map_replace(incoming_requests2,key,timeout); 
     }
     //loop releated stuff


### PR DESCRIPTION
Connection will use delta time to allow the server and clients to have
different room speeds. Else the say the server got room speed 60 and the
client 30. Then the server will kick the client because the client ping
timeout is only half and the servers ping timeout will run out and kick
the client.

NOTE:
The  mp_sync still use the same step counter as before.