### PR TITLE
webber17 memory leak fix

### DIFF
--- a/GMnetENGINE.gmx/scripts/htme_cleanUpInstance.gml
+++ b/GMnetENGINE.gmx/scripts/htme_cleanUpInstance.gml
@@ -23,6 +23,8 @@ with inst {
      var key= ds_map_find_first(self.htme_mp_groups);
      for(var i=0; i<ds_map_size(self.htme_mp_groups); i+=1) {
          var group = ds_map_find_value(self.htme_mp_groups,key);
+         var var_list = ds_map_find_value(group,"variables");
+         if ds_exists(var_list,ds_type_list) then ds_list_destroy(var_list);    
          var list_ind = ds_list_find_index(global.htme_object.grouplist,group);
          if (list_ind != -1)
             ds_list_delete(global.htme_object.grouplist,list_ind);


### PR DESCRIPTION
webber17 memory leak fix when clients disconnect the map "variables" is
now destroyed.