### PR TITLE
Some more memory leak fixes

### DIFF
--- a/GMnetENGINE.gmx/GMnetENGINE.project.gmx
+++ b/GMnetENGINE.gmx/GMnetENGINE.project.gmx
@@ -104,6 +104,7 @@
         <script>scripts\htme_clientIsConnected.gml</script>
         <script>scripts\htme_clientConnectionFailed.gml</script>
         <script>scripts\htme_isStarted.gml</script>
+        <script>scripts\htme_isLostConnection.gml</script>
         <script>scripts\htme_isServer.gml</script>
         <script>scripts\htme_getPlayers.gml</script>
         <script>scripts\htme_findPlayerInstance.gml</script>
@@ -116,6 +117,7 @@
           <script>scripts\htme_commitData.gml</script>
         </scripts>
         <script>scripts\htme_getPlayerNumber.gml</script>
+        <script>scripts\htme_disconnectNow.gml</script>
         <script>scripts\htme_serverDisconnect.gml</script>
         <script>scripts\htme_serverShutdown.gml</script>
         <script>scripts\htme_clientDisconnect.gml</script>
@@ -227,6 +229,7 @@
           <script>scripts\htme_chatAddToQueue.gml</script>
           <script>scripts\htme_chatAddChannel.gml</script>
           <script>scripts\htme_clean_mp_sync.gml</script>
+          <script>scripts\htme_clean_connect_leftovers.gml</script>
         </scripts>
         <scripts name="signed_packets">
           <script>scripts\htme_sendNewSignedPacket.gml</script>

--- a/GMnetENGINE.gmx/objects/htme_obj_network_control.object.gmx
+++ b/GMnetENGINE.gmx/objects/htme_obj_network_control.object.gmx
@@ -113,9 +113,14 @@
           <argument>
             <kind>1</kind>
             <string>///Check if engine running
-if (!htme_isStarted()) {
-    show_message("Game Server or Client died! Restarting game...");
-    game_restart();
+if (htme_isLostConnection()) {
+    show_message("Game Server or Client died! Go back to menu...");
+    
+    // Clean other persistent non synced objects from room
+    with htme_obj_chat instance_destroy();
+    with htme_obj_playerlist instance_destroy();    
+    
+    room_goto(htme_rom_menu);
 }
 </string>
           </argument>

--- a/GMnetENGINE.gmx/objects/htme_obj_waitforclient.object.gmx
+++ b/GMnetENGINE.gmx/objects/htme_obj_waitforclient.object.gmx
@@ -31,7 +31,8 @@ if (htme_clientIsConnected()) {
 }
 if (htme_clientConnectionFailed()) {
     show_message("Connection with server failed!");
-    game_restart();
+    htme_clientStop();
+    room_goto(htme_rom_menu);
 }
 </string>
           </argument>

--- a/GMnetENGINE.gmx/objects/obj_htme.object.gmx
+++ b/GMnetENGINE.gmx/objects/obj_htme.object.gmx
@@ -49,14 +49,8 @@ htme_init();
         <arguments>
           <argument>
             <kind>1</kind>
-            <string>///Disconnect or kick clients if started
-if (!self.isConnected) exit;
-
-if (self.isServer) {
-    htme_serverShutdown();
-} else {
-    htme_clientDisconnect();
-}
+            <string>/// udphp destroyed us we must clean some now
+htme_clean_connect_leftovers();
 </string>
           </argument>
         </arguments>
@@ -151,6 +145,30 @@ htme_roomend();
         <arguments>
           <argument>
             <kind>1</kind>
+            <string>/// Re-init if disconnected in last room
+if self.clientStopped = true {
+    htme_init(true);
+}
+</string>
+          </argument>
+        </arguments>
+      </action>
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
             <string>///htme_roomstart(); - Sync current room
 htme_roomstart();
 </string>
@@ -176,12 +194,15 @@ htme_roomstart();
           <argument>
             <kind>1</kind>
             <string>///Disconnect or kick clients if started
-if (!self.isConnected) exit;
-
-if (self.isServer) {
-    htme_serverShutdown();
-} else {
-    htme_clientDisconnect();
+// Tell client/server that we want to disconnect now
+if htme_disconnectNow()
+{
+    // If disconnect is ok then do some cleaning
+    // Remove persistent but not synced objects
+    with htme_obj_chat instance_destroy();
+    with htme_obj_playerlist instance_destroy();
+    // Go back to menu room
+    room_goto(htme_rom_menu);    
 }
 </string>
           </argument>
@@ -207,6 +228,39 @@ if (self.isServer) {
             <kind>1</kind>
             <string>///htme_debugoverlay(); - Draw debug overlay
 htme_debugoverlay();
+</string>
+          </argument>
+        </arguments>
+      </action>
+    </event>
+    <event eventtype="9" enumb="27">
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>/// Shutdown client or server
+// Tell client/server that we want to shutdown now
+if htme_disconnectNow()
+{
+    // If disconnect is ok then do some cleaning
+    // Remove persistent but not synced objects
+    with htme_obj_chat instance_destroy();
+    with htme_obj_playerlist instance_destroy();
+    // Go back to menu room
+    room_goto(htme_rom_menu);    
+}
 </string>
           </argument>
         </arguments>

--- a/GMnetENGINE.gmx/scripts/htme_clean_connect_leftovers.gml
+++ b/GMnetENGINE.gmx/scripts/htme_clean_connect_leftovers.gml
@@ -1,0 +1,23 @@
+/// htme_clean_connect_leftovers();
+/*
+**  Description:
+**      PRIVATE "METHOD" OF obj_htme! That means this script MUST be called with obj_htme!
+**
+**      Clean must have connect maps. When disconnect we must have these maps
+**      But if we destroy/re-init the obj_htme we must destroy these maps
+**
+**  Usage:
+**      <See above>
+**
+**  Arguments:
+**      <none>
+**
+**  Returns:
+**      <nothing>
+**
+*/
+
+ds_map_destroy(self.localInstances);
+ds_map_destroy(self.globalInstances);
+ds_map_destroy(self.sPcountOUT);
+ds_map_destroy(self.sPcountIN);

--- a/GMnetENGINE.gmx/scripts/htme_disconnectNow.gml
+++ b/GMnetENGINE.gmx/scripts/htme_disconnectNow.gml
@@ -1,0 +1,37 @@
+///htme_disconnectNow()
+
+/*
+**  Description:
+**      Disconnect and clean client or server when game started
+**      This is very handy, just call it and if return true then 
+**      clean your ds maps and lists and go to another room
+**      This will restart the engine, ready to to whatever you want.
+**      Like connect again, start server, lobby...
+**      Like a game restart without the game_restart()
+**  
+**  Usage:
+**      <see above>
+**
+**  Arguments:
+**      <none>
+**
+**  Returns:
+**      true, if ok disconnect, false if not.
+**
+*/
+if instance_exists(global.htme_object) {
+    with global.htme_object {
+        if (self.isConnected) {
+            // Clean everything
+            if self.isServer {
+                with global.htme_object htme_serverShutdown();
+            } else {
+                with global.htme_object htme_clientDisconnect();
+            }
+            return true;
+        }
+    }
+} else {
+    return false;
+}
+return false;

--- a/GMnetENGINE.gmx/scripts/htme_init.gml
+++ b/GMnetENGINE.gmx/scripts/htme_init.gml
@@ -1,4 +1,4 @@
-///htme_init()
+///htme_init([bool re-init])
 
 /* 
 **   _    _            _ 
@@ -39,6 +39,14 @@
 /*=================
  *** BELOW: INTERNAL VARIABLES - DO NOT CHANGE 
  =================*/
+ 
+// Handle reinit if disconnected once
+if argument_count>0 {
+    if argument[0]=true {
+        // Clear old ds
+        htme_clean_connect_leftovers();
+    }
+}
  
 /** 
  * ID of the Object that controls the engine. You normally don't have to change this.

--- a/GMnetENGINE.gmx/scripts/htme_isLostConnection.gml
+++ b/GMnetENGINE.gmx/scripts/htme_isLostConnection.gml
@@ -1,0 +1,28 @@
+///htme_isLostConnection()
+
+/*
+**  Description:
+**      This checks if a client or Server is Lost Connection
+**      This is very handy when you handle client exit if the server
+**      kicked you. Just check if this returns true then go to another room.
+**  
+**  Usage:
+**      <see above>
+**
+**  Arguments:
+**      <none>
+**
+**  Returns:
+**      true, if lost, false if not.
+**
+*/
+if instance_exists(global.htme_object) {
+    if (!htme_isStarted()) {
+        // Clean everything
+        with global.htme_object htme_clientDisconnect();
+        return true;
+    }
+} else {
+    return true;
+}
+return false;

--- a/GMnetENGINE.gmx/scripts/htme_networking_searchForBroadcasts.gml
+++ b/GMnetENGINE.gmx/scripts/htme_networking_searchForBroadcasts.gml
@@ -54,6 +54,10 @@ with (global.htme_object) {
             for (var i = 0;i<ds_list_size(serverlist);i++) {
                 var valmap = ds_list_find_value(serverlist,i)
                 if (valmap[? "ip"] == map[? "ip"]) {
+                    // remove old map
+                    if ds_exists(serverlist[| i],ds_type_map) {
+                        ds_map_destroy(serverlist[| i]);
+                    }
                     ds_list_replace(serverlist,i,map);
                     exit;
                 }

--- a/GMnetENGINE.gmx/scripts/htme_roomend.gml
+++ b/GMnetENGINE.gmx/scripts/htme_roomend.gml
@@ -54,6 +54,7 @@ for(var i=0; i<ds_map_size(mapToUse); i+=1) {
               ds_map_delete(self.globalInstances,insthash);
            }
             /* (2) */ 
+            // Handle persistent
             if ((instid).persistent) {
                htme_debugger("htme_roomend",htme_debug.INFO,"Destroyed a persistent global instance "+insthash+"!");
                // On server do a simple clean but on client do a full sweep
@@ -68,6 +69,21 @@ for(var i=0; i<ds_map_size(mapToUse); i+=1) {
                      instance_destroy();
                    }              
                }
+            } else {
+               // Handle non persistent
+               htme_debugger("htme_roomend",htme_debug.INFO,"Destroyed a global instance "+insthash+"!");
+               // On server do a simple clean but on client do a full sweep
+               if (self.isServer) {
+                   with instid {
+                     htme_clean_mp_sync();
+                     instance_destroy();
+                   }
+               } else {
+                   htme_cleanUpInstance(instid);
+                   with instid {
+                     instance_destroy();
+                   }              
+               }                
             }
         } else if (!(instid).persistent) {
            htme_debugger("htme_roomend",htme_debug.DEBUG,"Unregistered a local instance "+insthash+"!");

--- a/GMnetENGINE.gmx/scripts/htme_shutdown.gml
+++ b/GMnetENGINE.gmx/scripts/htme_shutdown.gml
@@ -33,6 +33,8 @@ for(var i=0; i<ds_map_size(self.localInstances); i+=1) {
         if wasServer 
             htme_serverRemoveBackup(key);
         with inst_id {instance_destroy();}
+    } else if wasServer {
+        htme_serverRemoveBackup(key);
     }
     key = ds_map_find_next(self.localInstances, key);
 }
@@ -44,6 +46,8 @@ for(var i=0; i<ds_map_size(self.globalInstances); i+=1) {
         if wasServer
             htme_serverRemoveBackup(key);        
         with inst_id {instance_destroy();}
+    } else if wasServer {
+        htme_serverRemoveBackup(key);
     }
     key = ds_map_find_next(self.globalInstances, key);
 }
@@ -56,7 +60,7 @@ self.socketOrServer = -1;
 self.server_ip = "";
 self.playerhash = "";
 self.server_port = 0;
-if (ds_exists(self.udphp_playerlist, ds_type_map)) {ds_map_destroy(self.udphp_playerlist);}
+if (ds_exists(self.udphp_playerlist, ds_type_list)) {ds_list_destroy(self.udphp_playerlist);}
 if (ds_exists(self.playermap, ds_type_map)) {ds_map_destroy(self.playermap);}
 if (ds_exists(self.kickmap, ds_type_map)) {ds_map_destroy(self.kickmap);}
 if (ds_exists(self.playerrooms, ds_type_map)) {ds_map_destroy(self.playerrooms);}
@@ -70,6 +74,17 @@ if (ds_exists(self.serverTimeoutRecv, ds_type_map)) {ds_map_destroy(self.serverT
 if (ds_exists(self.signedPacketsCategories, ds_type_map)) {ds_map_destroy(self.signedPacketsCategories);}
 if (ds_exists(self.serverBackup, ds_type_map)) {ds_map_destroy(self.serverBackup);}
 if (ds_exists(self.signedPackets, ds_type_list)) {ds_list_destroy(self.signedPackets);}
+if (ds_exists(self.lanlobby, ds_type_list)) {
+    // Clean list from ds maps
+    for (var i=0; i<ds_list_size(self.lanlobby); i+=1)
+    {
+        if ds_exists(self.lanlobby[| i],ds_type_map) {
+            ds_map_destroy(self.lanlobby[| i]);
+        }
+    }
+    ds_list_destroy(self.lanlobby);
+}
+
 htme_clean_signed_packets("");
 ds_map_destroy(self.sPcountOUT);
 self.sPcountOUT = ds_map_create();

--- a/GMnetENGINE.gmx/scripts/htme_startLANsearch.gml
+++ b/GMnetENGINE.gmx/scripts/htme_startLANsearch.gml
@@ -44,10 +44,17 @@ if (argument_count > 1) {
 }
 
 with (global.htme_object) {
+    // Clean list from ds maps
+    for (var i=0; i<ds_list_size(self.lanlobby); i+=1)
+    {
+        if ds_exists(self.lanlobby[| i],ds_type_map) {
+            ds_map_destroy(self.lanlobby[| i]);
+        }
+    }
     ds_list_destroy(self.lanlobby);
     self.lanlobby = ds_list_create();
     self.lanlobbyport = port;
     self.lanlobbysearch = true;
     self.lanlobbyfilter = gamefilter;
     self.lanlobbysearchserver = network_create_server(network_socket_udp,port+1,32);
-}
+}

--- a/GMnetENGINE.gmx/scripts/udphp_downloadServerList.gml
+++ b/GMnetENGINE.gmx/scripts/udphp_downloadServerList.gml
@@ -115,8 +115,18 @@ if (argument_count > 10) {
 
 if (ds_exists(global.udphp_downloadlist_topmap,ds_type_map)) {
    ds_map_destroy(global.udphp_downloadlist_topmap);
+   global.udphp_downloadlist_topmap=-1;
 }
-global.udphp_downloadlist = -1;
+if (ds_exists(global.udphp_downloadlist,ds_type_list)) {
+    for (var i=0; i<ds_list_size(global.udphp_downloadlist); i+=1)
+    {
+        if (ds_exists(global.udphp_downloadlist[| i],ds_type_map)) {
+            ds_map_destroy(global.udphp_downloadlist[| i]);
+        }
+    }
+    ds_list_destroy(global.udphp_downloadlist);
+    global.udphp_downloadlist = -1;
+}
 global.udphp_downloadlist_refreshing = true;
 
 var buffer = buffer_create(256, buffer_grow, 1);

--- a/GMnetENGINE.gmx/scripts/udphp_stopClient.gml
+++ b/GMnetENGINE.gmx/scripts/udphp_stopClient.gml
@@ -28,5 +28,19 @@ if (!instance_exists(client)) {
     exit;
 }
 
+// Clean others
+if ds_exists(global.udphp_downloadlist_topmap,ds_type_map) {
+    ds_map_destroy(global.udphp_downloadlist_topmap);
+    global.udphp_downloadlist_topmap=-1;
+}
+if ds_exists(global.udphp_downloadlist,ds_type_list) {
+    ds_list_destroy(global.udphp_downloadlist);
+    global.udphp_downloadlist=-1;
+}
+if ds_exists(global.udphp_clients,ds_type_map) {
+    ds_map_destroy(global.udphp_clients);
+    global.udphp_clients=-1;
+}
+
 with (client) {instance_destroy();}
-udphp_handleerror(udphp_dbglvl.DEBUG, udphp_dbgtarget.CLIENT, client, "Client stopped...");
+udphp_handleerror(udphp_dbglvl.DEBUG, udphp_dbgtarget.CLIENT, client, "Client stopped...");


### PR DESCRIPTION
Here comes more leak fixes.
This also change the way the engine restarts. We dont use game_restart() anymore.
Press Esc in the game and the engine will clean everything and go back to main menu. You can do thesame when a client lost the connection. Just check htme_isLostConnection and it will clean everything and you can go to any room. The engine will re-init when in the new room.