### PR TITLE
Missing delta time variable

### DIFF
--- a/GMnetENGINE.gmx/scripts/htme_config.gml
+++ b/GMnetENGINE.gmx/scripts/htme_config.gml
@@ -50,12 +50,21 @@ self.udphp_master_ip = "95.85.63.183";
 self.udphp_master_port = 6510;
 
 /** 
+ * Use delta time instead of room step counter
+ * If you set to true you must remove all the room_speed
+ * from the timers below. And in the mp_addPosition("Pos",5*room_speed);
+ * remove the room_speed. The engine will use seconds instead of steps.
+ * @type bool
+ */
+use_delta_time=false;
+
+/** 
  * WHEN USING GMnet PUNCH:
  * The server should reconnect to the master server every x steps.
  * The server will only reconnect if it's no longer connected.
  * @type real
  */
-self.udphp_rctintv = 3*60;
+self.udphp_rctintv = 3*60*room_speed;
 
 /** 
  * The timeout after which the client gives up to connect.
@@ -65,7 +74,7 @@ self.udphp_rctintv = 3*60;
  * The timeout after which the server and client give up to connect to each other.
  * @type real
  */
-self.global_timeout = 5;
+self.global_timeout = 5*room_speed;
 
 /** 
  * WHEN USING GMnet PUNCH:
@@ -77,13 +86,13 @@ self.global_timeout = 5;
  * But this will decrease the chances you connect to the server
  * @type real
  */
-self.punch_stage_timeout=1; // must wait 1 sec before next try else the Messages wont be sent or the target router will stop them
+self.punch_stage_timeout=1*room_speed; // must wait 1 sec before next try else the Messages wont be sent or the target router will stop them
 
 /** 
  * Interval the servers broadcast data to the LAN, for the LAN lobby
  * @type real
  */
-self.lan_interval = 15;
+self.lan_interval = 15*room_speed;
 
 /**
  *  Shortname of this game


### PR DESCRIPTION
The delta time variable was missing in htme_config. I don't know why. But this fix it.
It reset the engine to use room speed as default.