### PR TITLE
Max clients now works

### DIFF
--- a/GMnetENGINE.gmx/objects/htme_obj_waitforclient.object.gmx
+++ b/GMnetENGINE.gmx/objects/htme_obj_waitforclient.object.gmx
@@ -30,7 +30,7 @@ if (htme_clientIsConnected()) {
     room_goto(htme_rom_demo);
 }
 if (htme_clientConnectionFailed()) {
-    htme_error_message_handler("Connection with server failed!");
+    htme_error_message_handler("Connection with server failed, it may be full!");
     htme_clientStop();
     room_goto(htme_rom_menu);
 }

--- a/GMnetENGINE.gmx/scripts/htme_init.gml
+++ b/GMnetENGINE.gmx/scripts/htme_init.gml
@@ -206,6 +206,8 @@ self.tmp_instanceForceCreated = false;
 self.grouplist = -1;
 //The same for only local instances (server)
 self.grouplist_local = -1;
+// max connecting clients
+self.maxConnectingClients = 0;
 //
 self.tmp_creatingNetworkInstanceHash = "";
 //the 7 data strings (2-8)

--- a/GMnetENGINE.gmx/scripts/htme_serverConnectNetworking.gml
+++ b/GMnetENGINE.gmx/scripts/htme_serverConnectNetworking.gml
@@ -43,9 +43,11 @@ if (is_undefined(ds_map_find_value(self.playermap,in_ip+":"+string(in_port)))) {
         case htme_packet.CLIENT_GREETINGS:
             var cversion = buffer_read(in_buff, buffer_u16);
             var cgamename = buffer_read(in_buff, buffer_string);
+            // Get currently connected clients
+            var numConnectedClients = ds_list_size(global.htme_object.playerlist);
             //Check if compatible
-            if (self.gamename != cgamename || cversion < self.version_mayor || cversion >= self.version_mayor+100) {
-                htme_debugger("htme_serverConnectNetworking",htme_debug.INFO,in_ip+":"+string(in_port)+" - Client kicked. Not compatible.");
+            if (self.gamename != cgamename || cversion < self.version_mayor || cversion >= self.version_mayor+100 || self.maxConnectingClients<=numConnectedClients) {
+                htme_debugger("htme_serverConnectNetworking",htme_debug.INFO,in_ip+":"+string(in_port)+" - Client kicked. Not compatible or max clients.");
                 //CONNECTION REFUSED
                 buffer_seek(self.buffer, buffer_seek_start, 0);
                 buffer_write(self.buffer, buffer_s8, htme_packet.SERVER_KICKREQ)

--- a/GMnetENGINE.gmx/scripts/htme_serverStart.gml
+++ b/GMnetENGINE.gmx/scripts/htme_serverStart.gml
@@ -23,6 +23,9 @@ with (global.htme_object) {
 var port = argument0;
 var maxclients = argument1;
 
+// Set max clients to engine
+self.maxConnectingClients = maxclients;
+
 //Create the server socket
 htme_debugger("htme_serverStart",htme_debug.DEBUG,"STARTING SERVER");
 switch (gmversionpick)


### PR DESCRIPTION
When start server with htme_serverStart(port,32) you set a max clients
number. Now if you set it to 2. You can only have the server player and
one connecting player (2 players) in the game. If someone else try to
connect the connection is refused.