### PR TITLE
Check if all variables got here

### DIFF
--- a/GMnetENGINE.gmx/objects/obj_upnp.object.gmx
+++ b/GMnetENGINE.gmx/objects/obj_upnp.object.gmx
@@ -153,6 +153,9 @@ with (global.htme_object)
     var in_id = ds_map_find_value(async_load, "id");
     var in_port = ds_map_find_value(async_load, "port");
     
+    // htme used the buffer so we need to rewind it
+    buffer_seek(in_buff, buffer_seek_start, 0);
+    
     //Read command
     code = buffer_read(in_buff, buffer_s8 );
     switch code 

--- a/GMnetENGINE.gmx/scripts/htme_clientRecieveVarGroup.gml
+++ b/GMnetENGINE.gmx/scripts/htme_clientRecieveVarGroup.gml
@@ -77,11 +77,17 @@ switch (datatype) {
         //Simple datatype
         var length = buffer_read(in_buff,buffer_u8);
         for (var l=0;l<length;l++) {
-            var vname = buffer_read(in_buff,buffer_string);
-            var vval = buffer_read(in_buff,datatype);
-            //Check tolerance
-            var checkedval = htme_RecieveVar(ds_map_find_value((instance).htme_mp_vars,vname),vval,tolerance,datatype);
-            ds_map_replace((instance).htme_mp_vars,vname,checkedval);
+            // we must check if we got more in buffer
+            // we may not get all variables if some is SMART
+            // so the length can be wrong
+            if (buffer_tell(in_buff)<buffer_get_size(in_buff))
+            {
+                var vname = buffer_read(in_buff,buffer_string);
+                var vval = buffer_read(in_buff,datatype);
+                //Check tolerance
+                var checkedval = htme_RecieveVar(ds_map_find_value((instance).htme_mp_vars,vname),vval,tolerance,datatype);
+                ds_map_replace((instance).htme_mp_vars,vname,checkedval);
+            }
         }
     break;
 }

--- a/GMnetENGINE.gmx/scripts/htme_serverRecieveVarGroup.gml
+++ b/GMnetENGINE.gmx/scripts/htme_serverRecieveVarGroup.gml
@@ -157,13 +157,19 @@ switch (datatype) {
         var backupVars = backupEntry[? "backupVars"];
         var length = buffer_read(in_buff,buffer_u8);
         for (var l=0;l<length;l++) {
-            var vname = buffer_read(in_buff,buffer_string);
-            var vval = buffer_read(in_buff,datatype);
-            //Check tolerance
-            var checkedval = htme_RecieveVar(ds_map_find_value(backupVars,vname),vval,tolerance,datatype);
-            with (instance) { ds_map_replace(self.htme_mp_vars,vname,checkedval);}
-            //Also add to backup
-            ds_map_replace(backupVars,vname,checkedval);
+            // we must check if we got more in buffer
+            // we may not get all variables if some is SMART
+            // so the length can be wrong
+            if (buffer_tell(in_buff)<buffer_get_size(in_buff))
+            {        
+                var vname = buffer_read(in_buff,buffer_string);
+                var vval = buffer_read(in_buff,datatype);
+                //Check tolerance
+                var checkedval = htme_RecieveVar(ds_map_find_value(backupVars,vname),vval,tolerance,datatype);
+                with (instance) { ds_map_replace(self.htme_mp_vars,vname,checkedval);}
+                //Also add to backup
+                ds_map_replace(backupVars,vname,checkedval);
+            }
         }
     break;
 }


### PR DESCRIPTION
When using SMART some variables will not be sent to the other end. But
the line:
var length = buffer_read(in_buff,buffer_u8);
get the length of the total variables count. But if the varaible is the
same value or in tolerance it won't get here. So we may read outside the
buffer. In gm 1.4.1567 this is ok. It return -3. But in 1.4.1749 GM now
always check if we read outside the buffer and shoot us. This will make
us bulletproof :-)