### PR TITLE
Some fix for 1.4.1749

### DIFF
--- a/GMnetENGINE.gmx/scripts/htme_cleanUpInstance.gml
+++ b/GMnetENGINE.gmx/scripts/htme_cleanUpInstance.gml
@@ -18,29 +18,31 @@
 var inst = argument0;
 
 with inst {
-     
-     //Clean up groups -> {entry} -> variables and remove from list
-     var key= ds_map_find_first(self.htme_mp_groups);
-     for(var i=0; i<ds_map_size(self.htme_mp_groups); i+=1) {
-         var group = ds_map_find_value(self.htme_mp_groups,key);
-         var var_list = ds_map_find_value(group,"variables");
-         if is_undefined(var_list) var_list=-1;
-         if ds_exists(var_list,ds_type_list) then {ds_list_destroy(var_list);}
-         var list_ind = ds_list_find_index(global.htme_object.grouplist,group);
-         if (list_ind != -1)
-            ds_list_delete(global.htme_object.grouplist,list_ind);
-         var list_ind2 = ds_list_find_index(global.htme_object.grouplist_local,group);
-         if (list_ind2 != -1)
-            ds_list_delete(global.htme_object.grouplist_local,list_ind2);
-         ds_map_destroy(group);
-         key = ds_map_find_next(self.htme_mp_groups, key);
+     if (ds_exists(self.htme_mp_groups,ds_type_map))
+     {
+         //Clean up groups -> {entry} -> variables and remove from list
+         var key= ds_map_find_first(self.htme_mp_groups);
+         for(var i=0; i<ds_map_size(self.htme_mp_groups); i+=1) {
+             var group = ds_map_find_value(self.htme_mp_groups,key);
+             var var_list = ds_map_find_value(group,"variables");
+             if is_undefined(var_list) var_list=-1;
+             if ds_exists(var_list,ds_type_list) then {ds_list_destroy(var_list);}
+             var list_ind = ds_list_find_index(global.htme_object.grouplist,group);
+             if (list_ind != -1)
+                ds_list_delete(global.htme_object.grouplist,list_ind);
+             var list_ind2 = ds_list_find_index(global.htme_object.grouplist_local,group);
+             if (list_ind2 != -1)
+                ds_list_delete(global.htme_object.grouplist_local,list_ind2);
+             ds_map_destroy(group);
+             key = ds_map_find_next(self.htme_mp_groups, key);
+         }
      }
-     ds_map_destroy(self.htme_mp_vars_recv);
+     if (ds_exists(self.htme_mp_vars_recv,ds_type_map)) ds_map_destroy(self.htme_mp_vars_recv);
      self.htme_mp_vars_recv=-1;
-     ds_map_destroy(self.htme_mp_groups);
+     if (ds_exists(self.htme_mp_groups,ds_type_map)) ds_map_destroy(self.htme_mp_groups);
      self.htme_mp_groups=-1;
-     ds_map_destroy(self.htme_mp_vars);
+     if (ds_exists(self.htme_mp_vars,ds_type_map)) ds_map_destroy(self.htme_mp_vars);
      self.htme_mp_vars=-1;
-     ds_map_destroy(self.htme_mp_vars_sync);
+     if (ds_exists(self.htme_mp_vars_sync,ds_type_map)) ds_map_destroy(self.htme_mp_vars_sync);
      self.htme_mp_vars_sync=-1;
 }

--- a/GMnetENGINE.gmx/scripts/htme_syncSingleVarGroup.gml
+++ b/GMnetENGINE.gmx/scripts/htme_syncSingleVarGroup.gml
@@ -32,6 +32,7 @@ if (!self.isServer && self.playerhash == "") {
 /**RETRIEVE INFORMATION**/
 var inst_hash = group[? "instancehash"];
 var inst = group[? "instance"];
+var inst_player = noone;
 if (instance_exists(inst)) {
     var inst_groups = (inst).htme_mp_groups;
     var inst_object = (inst).htme_mp_object;
@@ -39,6 +40,7 @@ if (instance_exists(inst)) {
     var inst_stayAlive =  (inst).htme_mp_stayAlive;
 } else if (self.isServer) {
     var backupEntry = ds_map_find_value(self.serverBackup,inst_hash);
+    if is_undefined(backupEntry) backupEntry=-4;
     if (ds_exists(backupEntry,ds_type_map)) {
         var inst_groups = backupEntry[? "groups"];
         var inst_object = backupEntry[? "object"];


### PR DESCRIPTION
ds_exists no longer can use undefined (-1) values.
Fixed bug when backup entry dont exist the inst_player variabel is not
defined but used in code, even if the backup entry dont exist.