### PR TITLE
Independent server and client

### DIFF
--- a/GMnetENGINE.gmx/scripts/htme_config.gml
+++ b/GMnetENGINE.gmx/scripts/htme_config.gml
@@ -25,6 +25,13 @@ self.debugoverlay = true;
 self.gmversionpick=1;
 
 /** 
+ * Use string id for rooms and objects
+ * Allow to create separete server/client project
+ * Engine will use the objects and rooms string names instead of the gm id number
+ */
+self.use_string_as_id=false;
+
+/** 
  * Use GMnet PUNCH? Set to true if GMnet PUNCH is installed and should be used to make the conection.
  * GMnet PUNCH is installed if you use GMnet ENGINE and needs to be installed manually
  * when using GMnet CORE.

--- a/GMnetENGINE.gmx/scripts/htme_recieveVarGroup.gml
+++ b/GMnetENGINE.gmx/scripts/htme_recieveVarGroup.gml
@@ -25,9 +25,25 @@ var in_port = ds_map_find_value(async_load, "port");
 
 var instancehash = buffer_read(in_buff,buffer_string);
 var playerhash = buffer_read(in_buff,buffer_string);
-var inst_room = buffer_read(in_buff,buffer_u16);
+if use_string_as_id=false
+{
+    var inst_room = buffer_read(in_buff,buffer_u16);
+}
+else
+{
+    var inst_room = buffer_read(in_buff,buffer_string);
+    inst_room=asset_get_index(inst_room);
+}
 var groupname = buffer_read(in_buff,buffer_string);
-var object_id = buffer_read(in_buff,buffer_u16);
+if use_string_as_id=false
+{
+    var object_id = buffer_read(in_buff,buffer_u16);
+}
+else
+{
+    var object_id = buffer_read(in_buff,buffer_string);
+    object_id=asset_get_index(object_id);
+}
 var inst_stayAlive = buffer_read(in_buff,buffer_bool);
 var instance = ds_map_find_value(self.globalInstances,instancehash);
 var tolerance = buffer_read(in_buff,buffer_f32);

--- a/GMnetENGINE.gmx/scripts/htme_syncSingleVarGroup.gml
+++ b/GMnetENGINE.gmx/scripts/htme_syncSingleVarGroup.gml
@@ -103,11 +103,25 @@ buffer_write(self.buffer, buffer_string, inst_hash);
 //Write player
 buffer_write(self.buffer, buffer_string, inst_player);
 //Write room
-buffer_write(self.buffer, buffer_u16, inst_room);
+if use_string_as_id=false
+{
+    buffer_write(self.buffer, buffer_u16, inst_room);
+}
+else
+{
+    buffer_write(self.buffer, buffer_string, room_get_name(inst_room));
+}
 //Write groupname
 buffer_write(self.buffer, buffer_string, group[? "name"]);
 //Write object id
-buffer_write(self.buffer, buffer_u16, inst_object);
+if use_string_as_id=false
+{
+    buffer_write(self.buffer, buffer_u16, inst_object);
+}
+else
+{
+    buffer_write(self.buffer, buffer_string, object_get_name(inst_object));
+}
 //Write stayAlive
 buffer_write(self.buffer,buffer_bool, inst_stayAlive);
 //Write tolerance


### PR DESCRIPTION
Allow to use string names as id instead of gm number id. This will allow
to create a separete server and client program. Each program still need
the synced objects but you can strip anything else out.

Also fix problems on crossplatform issues where gm dont use the same id
number for the objects and rooms on each platform.